### PR TITLE
Do not clone submodules in PyPI workflow

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -16,6 +16,4 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - run: uv build && uv publish


### PR DESCRIPTION
Closes #242.